### PR TITLE
Add maximum session duration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ A blockchain-based meditative tool for syncing digital assets and tracking mindf
 ## Contracts
 - `zen-token.clar`: Core token for rewards
 - `zen-nft.clar`: NFT contract for achievements
-- `zen-session.clar`: Session tracking logic
+- `zen-session.clar`: Session tracking logic with duration validation (5-180 minutes)
 
 ## Testing
 Run tests with: `clarinet test`
+
+## Session Guidelines
+- Minimum session length: 5 minutes
+- Maximum session length: 180 minutes (3 hours)
+- Earn 1 token per minute of meditation

--- a/contracts/zen-session.clar
+++ b/contracts/zen-session.clar
@@ -6,12 +6,14 @@
 )
 
 (define-constant min-session-length u5)
+(define-constant max-session-length u180)
 (define-constant tokens-per-minute u1)
 
 (define-public (start-session (duration uint))
   (let ((user tx-sender))
     (begin
       (asserts! (>= duration min-session-length) (err u100))
+      (asserts! (<= duration max-session-length) (err u101))
       (ok (map-set sessions user 
         {total-minutes: duration,
          last-session: block-height,

--- a/tests/zen-session.test.ts
+++ b/tests/zen-session.test.ts
@@ -1,0 +1,33 @@
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v1.0.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+  name: "Ensure session validation works",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet1 = accounts.get('wallet_1')!;
+    
+    // Test valid duration
+    let block = chain.mineBlock([
+      Tx.contractCall('zen-session', 'start-session', 
+        [types.uint(30)], 
+        wallet1.address)
+    ]);
+    assertEquals(block.receipts[0].result, '(ok true)');
+    
+    // Test too short duration
+    block = chain.mineBlock([
+      Tx.contractCall('zen-session', 'start-session', 
+        [types.uint(3)], 
+        wallet1.address)
+    ]);
+    assertEquals(block.receipts[0].result, '(err u100)');
+    
+    // Test too long duration
+    block = chain.mineBlock([
+      Tx.contractCall('zen-session', 'start-session', 
+        [types.uint(200)], 
+        wallet1.address)
+    ]);
+    assertEquals(block.receipts[0].result, '(err u101)');
+  },
+});


### PR DESCRIPTION
This PR adds validation for maximum meditation session duration to prevent unrealistic session lengths and potential abuse of the token earning mechanism.

Changes:
- Added max-session-length constant of 180 minutes (3 hours)
- Added validation check in start-session function
- Created comprehensive tests for duration validation
- Updated README with session guidelines

Reasoning:
The original contract allowed unlimited session durations, which could lead to:
1. Unrealistic meditation claims
2. Potential token farming abuse
3. Data integrity issues

The 3-hour maximum provides a reasonable upper limit while accommodating longer meditation retreats and experienced practitioners.

Impact:
- Improved contract security
- Better data quality for meditation tracking
- More realistic token distribution model

No breaking changes to existing functionality - only adds additional validation.